### PR TITLE
Updated to add project pages to site for ADAM, bdg-formats, and avocado.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ source/_stash
 source/stylesheets/screen.css
 vendor
 node_modules
+*~
+#*

--- a/source/_includes/custom/navigation.html
+++ b/source/_includes/custom/navigation.html
@@ -10,6 +10,7 @@
        {% endif %}
     </a></li>
   <li><a href="{{ root_url }}/">Blog</a></li>
+  <li><a href="{{ root_url }}/projects">Projects</a></li>
   <li><a href="{{ root_url }}/mail">Mailing List</a></li>
   <li><a href="{{ root_url }}/blog/archives">Archives</a></li>
 </ul>

--- a/source/projects/adam/index.markdown
+++ b/source/projects/adam/index.markdown
@@ -1,0 +1,54 @@
+---
+layout: page
+title: "Big Data Genomics &en; ADAM"
+date: 2014-03-04 19:46
+comments: true
+sharing: true
+footer: true
+---
+
+### ADAM: Data Alignment/Map
+
+ADAM provides both an application programming interface (API) and a command line interface (CLI)
+for manipulating genomic data on a computing cluster. ADAM operates on data stored inside of
+[Parquet](http://www.parquet.io) with the [bdg-formats](/projects/bdg-formats/) schemas,
+using [Apache Spark](http://spark.apache.org/), and provides scalable performance on clusters
+larger than 100 machines.
+
+ADAM is on [Github](https://github.com/bigdatagenomics/adam). Quick start guides are available
+for [running ADAM on EC2](https://github.com/bigdatagenomics/adam/wiki/Running-ADAM-on-EC2), and
+for [building ADAM for specific CDH releases](https://github.com/bigdatagenomics/adam/wiki/Running-ADAM-on-CDH-4-or-5).
+
+### Releases
+
+The latest available release of ADAM is 0.6.1. ADAM is available for projects using Maven or SBT
+through the [Sonatype OSS repository](https://docs.sonatype.org/display/Repository).
+
+### Support
+
+For support using ADAM, please contact the [ADAM developer mailing list](/mail/). Additionally, we
+track issues and feature enhancement requests through our
+[Github issue tracker](https://github.com/bigdatagenomics/adam/issues).
+
+### Citing
+
+ADAM has been described in a UC Berkeley EECS [technical report](http://www.eecs.berkeley.edu/Pubs/TechRpts/2013/EECS-2013-207.html).
+The Bibtex for this reference is:
+
+```
+@techreport{Massie:EECS-2013-207,
+    Author = {Massie, Matt and Nothaft, Frank and Hartl, Christopher and Kozanitis, Christos and Schumacher, André and Joseph, Anthony D. and Patterson, David A.},
+    Title = {ADAM: Genomics Formats and Processing Patterns for Cloud Scale Computing},
+    Institution = {EECS Department, University of California, Berkeley},
+    Year = {2013},
+    Month = {Dec},
+    URL = {http://www.eecs.berkeley.edu/Pubs/TechRpts/2013/EECS-2013-207.html},
+    Number = {UCB/EECS-2013-207}
+}
+```
+
+### Licensing
+
+ADAM is available under the [Apache 2](http://www.apache.org/licenses/LICENSE-2.0.html)
+open source software (OSS) license. This OSS license is non-viral, and places no restrictions on
+users who would like to use or modify the software.

--- a/source/projects/avocado/index.markdown
+++ b/source/projects/avocado/index.markdown
@@ -1,0 +1,24 @@
+---
+layout: page
+title: "Big Data Genomics &en; avocado"
+date: 2014-03-04 19:46
+comments: true
+sharing: true
+footer: true
+---
+
+### avocado: A Variant Caller, Distributed
+
+avocado is a distributed pipeline for calling variants, and is built on top of [Apache Spark](http://spark.apache.org/)
+and the [ADAM API](/projects/adam). avocado provides a highly configurable pipeline that can be
+used for the alignment, processing, and variant calling of genomes/exomes/targets. We are currently
+in the process of hardening avocado for clincial use, and expanding the avocado pipeline so that it
+can triage processing steps based on genomic complexity.
+
+avocado is on [Github](https://github.com/bigdatagenomics/avocado), and is in active development.
+
+### Licensing
+
+ADAM is available under the [Apache 2](http://www.apache.org/licenses/LICENSE-2.0.html)
+open source software (OSS) license. This OSS license is non-viral, and places no restrictions on
+users who would like to use or modify the software.

--- a/source/projects/bdg-formats/index.markdown
+++ b/source/projects/bdg-formats/index.markdown
@@ -1,0 +1,54 @@
+---
+layout: page
+title: "Big Data Genomics &en; bdg-formats"
+date: 2014-03-04 19:46
+comments: true
+sharing: true
+footer: true
+---
+
+### bdg-formats: Schemas for genomic data
+
+The bdg-formats project provides schemas for describing common genomic data, such as reads, reference
+oriented data, variants, genotypes, and assemblies. The schemas developed by this project use
+[Apache Avro](http://avro.apache.org), which allows use across most common programming languages
+and platforms. These schemas form the core data structures used in the [ADAM](/projects/adam/)
+project.
+
+bdg-formats is on [Github](https://github.com/bigdatagenomics/bdg-formats).
+
+### Releases
+
+Currently, the bdg-formats schemas are part of the ADAM 0.6.1 release. ADAM is available for
+projects using Maven or SBT through the [Sonatype OSS repository](https://docs.sonatype.org/display/Repository).
+We are working to deploy artifacts for non-JVM languages; watch this space for more info!
+
+### Support
+
+The bdg-formats parallel the development of ADAM. For support, please contact the
+[ADAM developer mailing list](/mail/). Additionally, we track issues and feature enhancement
+requests through our [Github issue tracker](https://github.com/bigdatagenomics/bdg-formats/issues).
+
+### Citing
+
+An early version of the bdg-formats schemas was been described in the UC Berkeley EECS
+[technical report](http://www.eecs.berkeley.edu/Pubs/TechRpts/2013/EECS-2013-207.html) for the
+ADAM project. The Bibtex for this reference is:
+
+```
+@techreport{Massie:EECS-2013-207,
+    Author = {Massie, Matt and Nothaft, Frank and Hartl, Christopher and Kozanitis, Christos and Schumacher, André and Joseph, Anthony D. and Patterson, David A.},
+    Title = {ADAM: Genomics Formats and Processing Patterns for Cloud Scale Computing},
+    Institution = {EECS Department, University of California, Berkeley},
+    Year = {2013},
+    Month = {Dec},
+    URL = {http://www.eecs.berkeley.edu/Pubs/TechRpts/2013/EECS-2013-207.html},
+    Number = {UCB/EECS-2013-207}
+}
+```
+
+### Licensing
+
+ADAM is available under the [Apache 2](http://www.apache.org/licenses/LICENSE-2.0.html)
+open source software (OSS) license. This OSS license is non-viral, and places no restrictions on
+users who would like to use or modify the software.

--- a/source/projects/index.markdown
+++ b/source/projects/index.markdown
@@ -1,0 +1,29 @@
+---
+layout: page
+title: "Projects"
+date: 2014-03-04 19:46
+comments: true
+sharing: true
+footer: true
+---
+
+Thanks to advances in both the cost and speed of sequencing technology, the amount of genomic
+data available for processing is growing exponentially. As a project, our goal is to build
+scalable pipelines for processing genomic data on top of high performance distributed
+computing frameworks.
+
+### Projects
+
+At the moment, we are working on three projects:
+
+* [ADAM](/projects/adam/): A scalable API & CLI for genome processing
+* [bdg-formats](/projects/bdg-formats): Schemas for genomic data
+* [avocado](/projects/avocado/): A Variant Caller, Distributed
+
+The source for these projects is available at [Github](http://www.github.com/bigdatagenomics).
+
+### Licensing
+
+All of our development is available under the [Apache 2](http://www.apache.org/licenses/LICENSE-2.0.html)
+open source software (OSS) license. This OSS license is non-viral, and places no restrictions on
+users who would like to use or modify the software.


### PR DESCRIPTION
Added a navigation tab for the three projects we have, as well as short pages that summarize what is found in each project, pointers to docs, etc.
